### PR TITLE
update to use new method to set output

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,8 +44,8 @@ func search() error {
 	fmt.Printf("Found issue %s\n", key)
 
 	// Special format log line to set output for the action.
-	// See https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-composite-run-steps-actions.
-	fmt.Printf("::set-output name=key::%s\n", key)
+	// See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
+	fmt.Printf("key=%s >> $GITHUB_OUTPUT\n", key)
 
 	return nil
 }


### PR DESCRIPTION
👋 
`save-state` and `set-output` are deprecated per
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/